### PR TITLE
Usage documentation and usage printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ go get -u github.com/qjcg/horeb
 
 Alternatively, you can download the [latest binary release here].
 
+## Usage
+### Basic Usage
+```
+go run main.go blocks.go -h
+horeb: Speaking in tongues via stdout
+  -c    colorize output
+  -d    print all Blocks
+  -h    prints usage documentation
+  -l    list all Block names and codepoint ranges
+  -n int
+        number of characters to print (default 30)
+```
+### Advanced usage
+The following line will print a sequence of 30 characters composed of characters from the geometric and emoji sets
+```
+./horeb -n=30 geometric emoji
+```
 
 ## Test
 

--- a/main.go
+++ b/main.go
@@ -22,13 +22,16 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	flag.Usage = usage
-
+	printusage := flag.Bool("h", false, "prints usage documentation")
 	color := flag.Bool("c", false, "colorize output")
 	dump := flag.Bool("d", false, "print all Blocks")
 	list := flag.Bool("l", false, "list all Block names and codepoint ranges")
 	nchars := flag.Int("n", 30, "number of characters to print")
 	flag.Parse()
-
+	if *printusage {
+		usage()
+		return
+	}
 	blocks := []string{"all"}
 	if flag.NArg() > 0 {
 		blocks = flag.Args()

--- a/main_test.go
+++ b/main_test.go
@@ -6,11 +6,20 @@ package main
 // go test -v -tags integration
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 )
 
 const cmdName = "horeb"
+
+func TestHelp(t *testing.T) {
+	out, err := exec.Command(cmdName, "-h").CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s\n%s\n", err, out)
+		fmt.Println(out)
+	}
+}
 
 func TestNoArgs(t *testing.T) {
 	out, err := exec.Command(cmdName).CombinedOutput()


### PR DESCRIPTION
the '-h' flag now prints the usage documentation. README.md has been
updated with the usage of the utility too.